### PR TITLE
deprecate socless_template_string

### DIFF
--- a/getting-started-tutorial/socless-tutorial/functions/send_message/lambda_function.py
+++ b/getting-started-tutorial/socless-tutorial/functions/send_message/lambda_function.py
@@ -1,5 +1,5 @@
 import slack, os
-from socless import socless_bootstrap, socless_template_string
+from socless import socless_bootstrap
 
 SOCLESS_BOT_TOKEN = os.environ.get('SOCLESS_BOT_TOKEN')
 sc = slack.WebClient(token=SOCLESS_BOT_TOKEN)
@@ -41,7 +41,7 @@ def handle_state(context, target, target_type, message_template):
         target_id = f"#{target}"
 
     # Render the message template and send the message
-    message = socless_template_string(message_template, context)
+    message = message_template
     resp = sc.chat_postMessage(channel=target_id, text=message, as_user=True)
     return resp.data
 


### PR DESCRIPTION
This is to deprecate old API: socless_template_string

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
